### PR TITLE
Check os.FileMode

### DIFF
--- a/cmd/slp/cmd/root.go
+++ b/cmd/slp/cmd/root.go
@@ -40,7 +40,7 @@ func NewRootCmd(version string) *cobra.Command {
 				if err != nil {
 					return err
 				}
-				if fi.Size() == 0 {
+				if fi.Mode()&os.ModeNamedPipe == 0 {
 					cmd.Usage()
 					slowlogFile.Close()
 					return nil


### PR DESCRIPTION
Hi @tkuchiki ! Thank you for the nice plugin.

I think `Stdin.Size()` method return 0 on at least my OS. And, [Documents](https://pkg.go.dev/io/fs#FileInfo) says `length in bytes for regular files; system-dependent for others`. I fixed to check os.FileMode.

### My Environment

```bash
$ uname -a
Linux archxps 5.18.1-arch1-1 #1 SMP PREEMPT_DYNAMIC Mon, 30 May 2022 17:53:11 +0000 x86_64 GNU/Linux
```

### Expected

```bash
$ cat /var/og/mysql/slow-query.log | slp
+-------+----------------------------------------------------------------------+----------------+----------------+----------------+----------------+
| COUNT |                                QUERY                                 | MIN(QUERYTIME) | MAX(QUERYTIME) | SUM(QUERYTIME) | AVG(QUERYTIME) |
+-------+----------------------------------------------------------------------+----------------+----------------+----------------+----------------+
| 1     | DELETE FROM `haveread`                                               | 0.000532       | 0.000532       | 0.000532       | 0.000532       |
| 1     | SELECT @@`version_comment`                                           | 0.000203       | 0.000203       | 0.000203       | 0.000203       |
+-------+----------------------------------------------------------------------+----------------+----------------+----------------+----------------+
```

### Actual

```bash
$ cat /var/og/mysql/slow-query.log | slp
Usage:
  slp [flags]
  slp [command]

Available Commands:
  completion           Generate the autocompletion script for the specified shell
  diff                 Show the difference between the two profile results
  help                 Help about any command
  print-output-options Print --output options

Flags:
      --bundle-values            Bundle VALUES of INSERT statement
      --bundle-where-in          Bundle WHERE IN conditions
      --config string            The configuration file
      --dump string              Dump profiled data as YAML
      --file string              The slowlog file
  -f, --filters string           Only the logs are profiled that match the conditions
      --format string            The output format (table, markdown, tsv, csv and html) (default "table")
  -h, --help                     help for slp
      --limit int                The maximum number of results to display (default 5000)
      --load string              Load the profiled YAML data
  -m, --matching-groups string   Specifies Query matching groups separated by commas
  -a, --noabstract               Do not abstract all numbers to N and strings to 'S'
      --noheaders                Output no header line at all (only --format=tsv, csv)
      --nosave-pos               Do not save position file
  -o, --output string            Specifies the results to display, separated by commas (default "simple")
      --page int                 Number of pages of pagination (default 100)
      --percentiles string       Specifies the percentiles separated by commas
      --pos string               The position file
  -r, --reverse                  Sort results in reverse order
      --show-footers             Output footer line at all (only --format=table, markdown)
      --sort string              Output the results in sorted order (default "count")
```