### PR TITLE
Resolve Undefined Flags Issue in slp diff Command

### DIFF
--- a/cmd/slp/cmd/diff.go
+++ b/cmd/slp/cmd/diff.go
@@ -85,6 +85,8 @@ func newDiffCmd(flags *flags) *cobra.Command {
 		},
 	}
 
+	flags.defineDiffOptions(diffCmd)
+
 	diffCmd.Flags().SortFlags = false
 	diffCmd.PersistentFlags().SortFlags = false
 	diffCmd.InheritedFlags().SortFlags = false

--- a/cmd/slp/cmd/diff_test.go
+++ b/cmd/slp/cmd/diff_test.go
@@ -1,0 +1,21 @@
+package cmd
+
+import "testing"
+
+func Test_newDiffCmd(t *testing.T) {
+	command := NewCommand("test")
+	slpDumpFile1 := "../../../example/slp-dump-1.yaml"
+	slpDumpFile2 := "../../../example/slp-dump-2.yaml"
+
+	args := []string{"diff",
+		slpDumpFile1,
+		slpDumpFile2,
+		"--show-footers",
+	}
+	command.setArgs(args)
+
+	err := command.Execute()
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/example/slp-dump-1.yaml
+++ b/example/slp-dump-1.yaml
@@ -1,0 +1,268 @@
+- query: DELETE FROM `t2` WHERE 'S' < `c1_date` OR `c2` NOT IN (SELECT `c3` FROM `t3`)
+  count: 1
+  query_time:
+    max: 0.369618
+    min: 0.369618
+    sum: 0.369618
+    usepercentile: false
+    percentiles: []
+  lock_time:
+    max: 2e-06
+    min: 2e-06
+    sum: 2e-06
+    usepercentile: false
+    percentiles: []
+  rows_sent:
+    max: 0
+    min: 0
+    sum: 0
+    usepercentile: false
+    percentiles: []
+  rows_examined:
+    max: 258959
+    min: 258959
+    sum: 258959
+    usepercentile: false
+    percentiles: []
+  rows_affected:
+    max: 0
+    min: 0
+    sum: 0
+    usepercentile: false
+    percentiles: []
+  bytes_sent:
+    max: 0
+    min: 0
+    sum: 0
+    usepercentile: false
+    percentiles: []
+- query: DELETE FROM `t4` WHERE `c4` NOT IN (SELECT `c1` FROM `t1`)
+  count: 1
+  query_time:
+    max: 7.148949
+    min: 7.148949
+    sum: 7.148949
+    usepercentile: false
+    percentiles: []
+  lock_time:
+    max: 4e-06
+    min: 4e-06
+    sum: 4e-06
+    usepercentile: false
+    percentiles: []
+  rows_sent:
+    max: 0
+    min: 0
+    sum: 0
+    usepercentile: false
+    percentiles: []
+  rows_examined:
+    max: 20720537
+    min: 20720537
+    sum: 20720537
+    usepercentile: false
+    percentiles: []
+  rows_affected:
+    max: 0
+    min: 0
+    sum: 0
+    usepercentile: false
+    percentiles: []
+  bytes_sent:
+    max: 0
+    min: 0
+    sum: 0
+    usepercentile: false
+    percentiles: []
+- query: UPDATE `t1` SET `c1_count`=(SELECT COUNT(N) AS `cnt` FROM `t2` WHERE `c3_id`
+    = `t3`.`id`)
+  count: 2
+  query_time:
+    max: 3.504247
+    min: 1.428614
+    sum: 4.932861
+    usepercentile: false
+    percentiles: []
+  lock_time:
+    max: 3e-06
+    min: 2e-06
+    sum: 4.9999999999999996e-06
+    usepercentile: false
+    percentiles: []
+  rows_sent:
+    max: 0
+    min: 0
+    sum: 0
+    usepercentile: false
+    percentiles: []
+  rows_examined:
+    max: 10486804
+    min: 3135871
+    sum: 13622675
+    usepercentile: false
+    percentiles: []
+  rows_affected:
+    max: 0
+    min: 0
+    sum: 0
+    usepercentile: false
+    percentiles: []
+  bytes_sent:
+    max: 0
+    min: 0
+    sum: 0
+    usepercentile: false
+    percentiles: []
+- query: INSERT INTO `t2` (`c2_id`,`c2_string`,`c2_date`) VALUES (N,'S','S')
+  count: 1
+  query_time:
+    max: 0.010498
+    min: 0.010498
+    sum: 0.010498
+    usepercentile: false
+    percentiles: []
+  lock_time:
+    max: 0
+    min: 0
+    sum: 0
+    usepercentile: false
+    percentiles: []
+  rows_sent:
+    max: 0
+    min: 0
+    sum: 0
+    usepercentile: false
+    percentiles: []
+  rows_examined:
+    max: 0
+    min: 0
+    sum: 0
+    usepercentile: false
+    percentiles: []
+  rows_affected:
+    max: 0
+    min: 0
+    sum: 0
+    usepercentile: false
+    percentiles: []
+  bytes_sent:
+    max: 0
+    min: 0
+    sum: 0
+    usepercentile: false
+    percentiles: []
+- query: INSERT INTO `t2` (`c2_id`,`c2_string`,`c2_date`) VALUES (N,'S','S'),(N,'S','S')
+  count: 1
+  query_time:
+    max: 0.010498
+    min: 0.010498
+    sum: 0.010498
+    usepercentile: false
+    percentiles: []
+  lock_time:
+    max: 0
+    min: 0
+    sum: 0
+    usepercentile: false
+    percentiles: []
+  rows_sent:
+    max: 0
+    min: 0
+    sum: 0
+    usepercentile: false
+    percentiles: []
+  rows_examined:
+    max: 0
+    min: 0
+    sum: 0
+    usepercentile: false
+    percentiles: []
+  rows_affected:
+    max: 0
+    min: 0
+    sum: 0
+    usepercentile: false
+    percentiles: []
+  bytes_sent:
+    max: 0
+    min: 0
+    sum: 0
+    usepercentile: false
+    percentiles: []
+- query: SELECT * FROM `t5` WHERE `c5_id` IN ('S','S','S')
+  count: 1
+  query_time:
+    max: 0.010753
+    min: 0.010753
+    sum: 0.010753
+    usepercentile: false
+    percentiles: []
+  lock_time:
+    max: 1e-06
+    min: 1e-06
+    sum: 1e-06
+    usepercentile: false
+    percentiles: []
+  rows_sent:
+    max: 67
+    min: 67
+    sum: 67
+    usepercentile: false
+    percentiles: []
+  rows_examined:
+    max: 67
+    min: 67
+    sum: 67
+    usepercentile: false
+    percentiles: []
+  rows_affected:
+    max: 0
+    min: 0
+    sum: 0
+    usepercentile: false
+    percentiles: []
+  bytes_sent:
+    max: 0
+    min: 0
+    sum: 0
+    usepercentile: false
+    percentiles: []
+- query: SELECT `t1`.`id` FROM `t1` JOIN `t2` ON `t2`.`t1_id` = `t1`.`id` WHERE `t2`.`t1_id`
+    = 'S' ORDER BY `t2`.`t1_id`
+  count: 1
+  query_time:
+    max: 0.020219
+    min: 0.020219
+    sum: 0.020219
+    usepercentile: false
+    percentiles: []
+  lock_time:
+    max: 1e-06
+    min: 1e-06
+    sum: 1e-06
+    usepercentile: false
+    percentiles: []
+  rows_sent:
+    max: 58
+    min: 58
+    sum: 58
+    usepercentile: false
+    percentiles: []
+  rows_examined:
+    max: 174
+    min: 174
+    sum: 174
+    usepercentile: false
+    percentiles: []
+  rows_affected:
+    max: 0
+    min: 0
+    sum: 0
+    usepercentile: false
+    percentiles: []
+  bytes_sent:
+    max: 0
+    min: 0
+    sum: 0
+    usepercentile: false
+    percentiles: []

--- a/example/slp-dump-2.yaml
+++ b/example/slp-dump-2.yaml
@@ -1,0 +1,268 @@
+- query: DELETE FROM `t2` WHERE 'S' < `c1_date` OR `c2` NOT IN (SELECT `c3` FROM `t3`)
+  count: 1
+  query_time:
+    max: 0.369618
+    min: 0.369618
+    sum: 0.369618
+    usepercentile: false
+    percentiles: []
+  lock_time:
+    max: 2e-06
+    min: 2e-06
+    sum: 2e-06
+    usepercentile: false
+    percentiles: []
+  rows_sent:
+    max: 0
+    min: 0
+    sum: 0
+    usepercentile: false
+    percentiles: []
+  rows_examined:
+    max: 258959
+    min: 258959
+    sum: 258959
+    usepercentile: false
+    percentiles: []
+  rows_affected:
+    max: 0
+    min: 0
+    sum: 0
+    usepercentile: false
+    percentiles: []
+  bytes_sent:
+    max: 0
+    min: 0
+    sum: 0
+    usepercentile: false
+    percentiles: []
+- query: DELETE FROM `t4` WHERE `c4` NOT IN (SELECT `c1` FROM `t1`)
+  count: 1
+  query_time:
+    max: 3.148949
+    min: 3.148949
+    sum: 3.148949
+    usepercentile: false
+    percentiles: []
+  lock_time:
+    max: 4e-06
+    min: 4e-06
+    sum: 4e-06
+    usepercentile: false
+    percentiles: []
+  rows_sent:
+    max: 0
+    min: 0
+    sum: 0
+    usepercentile: false
+    percentiles: []
+  rows_examined:
+    max: 20720537
+    min: 20720537
+    sum: 20720537
+    usepercentile: false
+    percentiles: []
+  rows_affected:
+    max: 0
+    min: 0
+    sum: 0
+    usepercentile: false
+    percentiles: []
+  bytes_sent:
+    max: 0
+    min: 0
+    sum: 0
+    usepercentile: false
+    percentiles: []
+- query: UPDATE `t1` SET `c1_count`=(SELECT COUNT(N) AS `cnt` FROM `t2` WHERE `c3_id`
+    = `t3`.`id`)
+  count: 1
+  query_time:
+    max: 6.504247
+    min: 6.504247
+    sum: 6.504247
+    usepercentile: false
+    percentiles: []
+  lock_time:
+    max: 3e-06
+    min: 3e-06
+    sum: 3e-06
+    usepercentile: false
+    percentiles: []
+  rows_sent:
+    max: 0
+    min: 0
+    sum: 0
+    usepercentile: false
+    percentiles: []
+  rows_examined:
+    max: 10486804
+    min: 10486804
+    sum: 10486804
+    usepercentile: false
+    percentiles: []
+  rows_affected:
+    max: 0
+    min: 0
+    sum: 0
+    usepercentile: false
+    percentiles: []
+  bytes_sent:
+    max: 0
+    min: 0
+    sum: 0
+    usepercentile: false
+    percentiles: []
+- query: INSERT INTO `t2` (`c2_id`,`c2_string`,`c2_date`) VALUES (N,'S','S')
+  count: 1
+  query_time:
+    max: 0.010498
+    min: 0.010498
+    sum: 0.010498
+    usepercentile: false
+    percentiles: []
+  lock_time:
+    max: 0
+    min: 0
+    sum: 0
+    usepercentile: false
+    percentiles: []
+  rows_sent:
+    max: 0
+    min: 0
+    sum: 0
+    usepercentile: false
+    percentiles: []
+  rows_examined:
+    max: 0
+    min: 0
+    sum: 0
+    usepercentile: false
+    percentiles: []
+  rows_affected:
+    max: 0
+    min: 0
+    sum: 0
+    usepercentile: false
+    percentiles: []
+  bytes_sent:
+    max: 0
+    min: 0
+    sum: 0
+    usepercentile: false
+    percentiles: []
+- query: INSERT INTO `t2` (`c2_id`,`c2_string`,`c2_date`) VALUES (N,'S','S'),(N,'S','S')
+  count: 1
+  query_time:
+    max: 0.010498
+    min: 0.010498
+    sum: 0.010498
+    usepercentile: false
+    percentiles: []
+  lock_time:
+    max: 0
+    min: 0
+    sum: 0
+    usepercentile: false
+    percentiles: []
+  rows_sent:
+    max: 0
+    min: 0
+    sum: 0
+    usepercentile: false
+    percentiles: []
+  rows_examined:
+    max: 0
+    min: 0
+    sum: 0
+    usepercentile: false
+    percentiles: []
+  rows_affected:
+    max: 0
+    min: 0
+    sum: 0
+    usepercentile: false
+    percentiles: []
+  bytes_sent:
+    max: 0
+    min: 0
+    sum: 0
+    usepercentile: false
+    percentiles: []
+- query: SELECT * FROM `t5` WHERE `c5_id` IN ('S','S','S')
+  count: 1
+  query_time:
+    max: 0.010753
+    min: 0.010753
+    sum: 0.010753
+    usepercentile: false
+    percentiles: []
+  lock_time:
+    max: 1e-06
+    min: 1e-06
+    sum: 1e-06
+    usepercentile: false
+    percentiles: []
+  rows_sent:
+    max: 67
+    min: 67
+    sum: 67
+    usepercentile: false
+    percentiles: []
+  rows_examined:
+    max: 67
+    min: 67
+    sum: 67
+    usepercentile: false
+    percentiles: []
+  rows_affected:
+    max: 0
+    min: 0
+    sum: 0
+    usepercentile: false
+    percentiles: []
+  bytes_sent:
+    max: 0
+    min: 0
+    sum: 0
+    usepercentile: false
+    percentiles: []
+- query: SELECT `t1`.`id` FROM `t1` JOIN `t2` ON `t2`.`t1_id` = `t1`.`id` WHERE `t2`.`t1_id`
+    = 'S' ORDER BY `t2`.`t1_id`
+  count: 1
+  query_time:
+    max: 0.020219
+    min: 0.020219
+    sum: 0.020219
+    usepercentile: false
+    percentiles: []
+  lock_time:
+    max: 1e-06
+    min: 1e-06
+    sum: 1e-06
+    usepercentile: false
+    percentiles: []
+  rows_sent:
+    max: 58
+    min: 58
+    sum: 58
+    usepercentile: false
+    percentiles: []
+  rows_examined:
+    max: 174
+    min: 174
+    sum: 174
+    usepercentile: false
+    percentiles: []
+  rows_affected:
+    max: 0
+    min: 0
+    sum: 0
+    usepercentile: false
+    percentiles: []
+  bytes_sent:
+    max: 0
+    min: 0
+    sum: 0
+    usepercentile: false
+    percentiles: []


### PR DESCRIPTION
## Overview

The `slp diff` command was throwing an error due to the undefined flags.

## Description

```bash
go run ./cmd/slp/main.go diff ./example/slp-dump-1.yaml ./example/slp-dump-2.yaml
2023/11/21 19:49:16 flag accessed but not defined: sort
exit status 1
```

```bash
go run ./cmd/slp/main.go diff --help
Show the difference between the two profile results

Usage:
  slp diff <from> <to> [flags]

Flags:
  -h, --help   help for diff

Global Flags:
      --config string   The configuration file

```

## Solution

- Referencing 'cmd/slp/cmd/mysql.go', added flag definitions to 'cmd/slp/cmd/diff.go'.
- Added simple tests to 'cmd/slp/cmd/diff_test.go'.


## Result

```bash
 go run ./cmd/slp/main.go diff ./example/slp-dump-1.yaml ./example/slp-dump-2.yaml
+--------+---------------------------------+-------------------+-------------------+-------------------+-------------------+
| COUNT  |              QUERY              |  MIN(QUERYTIME)   |  MAX(QUERYTIME)   |  SUM(QUERYTIME)   |  AVG(QUERYTIME)   |
+--------+---------------------------------+-------------------+-------------------+-------------------+-------------------+
| 1      | DELETE FROM `t2` WHERE 'S'      | 0.369618          | 0.369618          | 0.369618          | 0.369618          |
|        | < `c1_date` OR `c2` NOT IN      |                   |                   |                   |                   |
|        | (SELECT `c3` FROM `t3`)         |                   |                   |                   |                   |
| 1      | DELETE FROM `t4` WHERE `c4`     | 3.148949 (-4.000) | 3.148949 (-4.000) | 3.148949 (-4.000) | 3.148949 (-4.000) |
|        | NOT IN (SELECT `c1` FROM `t1`)  |                   |                   |                   |                   |
| 1 (-1) | UPDATE `t1` SET                 | 6.504247 (+5.076) | 6.504247 (+3.000) | 6.504247 (+1.571) | 6.504247 (+4.038) |
|        | `c1_count`=(SELECT COUNT(N) AS  |                   |                   |                   |                   |
|        | `cnt` FROM `t2` WHERE `c3_id`   |                   |                   |                   |                   |
|        | = `t3`.`id`)                    |                   |                   |                   |                   |
| 1      | INSERT INTO `t2`                | 0.010498          | 0.010498          | 0.010498          | 0.010498          |
|        | (`c2_id`,`c2_string`,`c2_date`) |                   |                   |                   |                   |
|        | VALUES (N,'S','S')              |                   |                   |                   |                   |
| 1      | INSERT INTO `t2`                | 0.010498          | 0.010498          | 0.010498          | 0.010498          |
|        | (`c2_id`,`c2_string`,`c2_date`) |                   |                   |                   |                   |
|        | VALUES (N,'S','S'),(N,'S','S')  |                   |                   |                   |                   |
| 1      | SELECT * FROM `t5` WHERE        | 0.010753          | 0.010753          | 0.010753          | 0.010753          |
|        | `c5_id` IN ('S','S','S')        |                   |                   |                   |                   |
| 1      | SELECT `t1`.`id` FROM `t1`      | 0.020219          | 0.020219          | 0.020219          | 0.020219          |
|        | JOIN `t2` ON `t2`.`t1_id` =     |                   |                   |                   |                   |
|        | `t1`.`id` WHERE `t2`.`t1_id` =  |                   |                   |                   |                   |
|        | 'S' ORDER BY `t2`.`t1_id`       |                   |                   |                   |                   |
+--------+---------------------------------+-------------------+-------------------+-------------------+-------------------+
```

```bash
go run ./cmd/slp/main.go diff --help
Show the difference between the two profile results

Usage:
  slp diff <from> <to> [flags]

Flags:
      --format string            The output format (table, markdown, tsv, csv, html) (default "table")
      --sort string              Output the results in sorted order (default "count")
  -r, --reverse                  Sort results in reverse order
      --noheaders                Output no header line at all (only --format=tsv, csv)
      --show-footers             Output footer line at all (only --format=table, markdown)
      --limit int                The maximum number of results to display (default 5000)
  -o, --output string            Specifies the results to display, separated by commas (default "simple")
  -m, --matching-groups string   Specifies Query matching groups separated by commas
  -f, --filters string           Only the logs are profiled that match the conditions
      --percentiles string       Specifies the percentiles separated by commas
      --page int                 Number of pages of pagination (default 100)
      --bundle-where-in          Bundle WHERE IN conditions
      --bundle-values            Bundle VALUES of INSERT statement
  -a, --noabstract               Do not abstract all numbers to N and strings to 'S'
  -h, --help                     help for diff

Global Flags:
      --config string   The configuration file
```

## Note to Reviewers
I haven't submitted many pull requests, so if there are any areas that need improvement or if I overlooked something, your feedback would be greatly appreciated. Thank you!
